### PR TITLE
Improve whitespace handling in preprocessing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+pytest_cache/
+.git/
+*.py[cod]
+*.joblib
+data/
+notebooks/
+tests/
+.DS_Store
+*.pytest_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY . /app
 RUN pip install --no-cache-dir .[web]
-CMD ["sentiment-web", "--model", "model.joblib"]
+CMD ["sentiment-web", "--model", "model.joblib", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ sentiment-cli predict your_reviews.csv --model my_model.joblib
 sentiment-cli eval data/labeled_reviews.csv
 sentiment-cli analyze data/labeled_reviews.csv
 ```
-12. Start the web server via the CLI:
+12. Start the web server via the CLI (binds to `127.0.0.1` by default):
    ```bash
    sentiment-cli serve --model my_model.joblib --port 5000
    ```
+   To expose it to other machines, pass `--host 0.0.0.0`.
 13. Check the installed package version:
    ```bash
    sentiment-cli version
@@ -137,7 +138,7 @@ To build a Docker image with all dependencies preinstalled and start the web ser
 
 ```bash
 docker build -t sentiment-pro .
-docker run -p 5000:5000 sentiment-pro
+docker run -p 5000:5000 sentiment-pro --host 0.0.0.0
 ```
 
 ## Web API
@@ -147,6 +148,8 @@ Run a lightweight Flask server to get predictions over HTTP using the CLI:
 ```bash
 sentiment-cli serve --model model.joblib
 ```
+By default the server is only available on `127.0.0.1`. Use
+`--host 0.0.0.0` to allow external access.
 
 You can also invoke the underlying web app directly with the
 `sentiment-web` command if preferred.

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Iterable, List
+import logging
 
 try:
     import pandas as pd
@@ -80,6 +81,8 @@ if __name__ == "__main__":  # pragma: no cover - convenience CLI
     parser = argparse.ArgumentParser(description="Evaluate sentiment model")
     parser.add_argument("csv", help="CSV file with 'text' and 'label' columns")
     args = parser.parse_args()
+    logging.basicConfig(format="%(message)s", level=logging.INFO, force=True)
+    logger = logging.getLogger(__name__)
 
     if pd is None:
         raise SystemExit("pandas is required for CLI usage")
@@ -87,6 +90,6 @@ if __name__ == "__main__":  # pragma: no cover - convenience CLI
     model = build_model()
     model.fit(df["text"], df["label"])
     preds = model.predict(df["text"])
-    print(evaluate(df["label"], preds))
-    print("Confusion matrix:")
-    print(compute_confusion(df["label"], preds))
+    logger.info(evaluate(df["label"], preds))
+    logger.info("Confusion matrix:")
+    logger.info(compute_confusion(df["label"], preds))

--- a/src/model_comparison.py
+++ b/src/model_comparison.py
@@ -17,6 +17,8 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     keras = None
 
+import logging
+
 from .models import build_lstm_model, build_model, build_transformer_model
 from .preprocessing import clean_text
 
@@ -64,12 +66,14 @@ def compare_models(csv_path: str = "data/sample_reviews.csv"):
         try:
             build_transformer_model()
             results.append({"model": "Transformer", "accuracy": 0.0})
-        except Exception:  # pragma: no cover - if transformer build fails
+        except (RuntimeError, ImportError):  # pragma: no cover - transformer optional
             pass
 
     return results
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format="%(message)s", level=logging.INFO, force=True)
+    logger = logging.getLogger(__name__)
     for result in compare_models():
-        print(f"{result['model']}: {result['accuracy']:.2f}")
+        logger.info("%s: %.2f", result["model"], result["accuracy"])

--- a/src/predict.py
+++ b/src/predict.py
@@ -1,5 +1,7 @@
 """Prediction script for baseline model."""
 
+import logging
+
 from .models import SentimentModel
 
 
@@ -11,8 +13,9 @@ def main(input_csv: str, model_path: str = "model.joblib"):
     data = pd.read_csv(input_csv)
     model: SentimentModel = joblib.load(model_path)
     predictions = model.predict(data["text"])
+    logger = logging.getLogger(__name__)
     for text, pred in zip(data["text"], predictions):
-        print(f"{text} => {pred}")
+        logger.info("%s => %s", text, pred)
 
 
 if __name__ == "__main__":
@@ -22,4 +25,5 @@ if __name__ == "__main__":
     parser.add_argument("csv", help="CSV file with a 'text' column")
     parser.add_argument("--model", default="model.joblib", help="Trained model path")
     args = parser.parse_args()
+    logging.basicConfig(format="%(message)s", level=logging.INFO, force=True)
     main(args.csv, args.model)

--- a/src/train.py
+++ b/src/train.py
@@ -1,5 +1,7 @@
 """Training script for baseline model."""
 
+import logging
+
 from .models import build_model
 
 
@@ -15,7 +17,7 @@ def main(csv_path: str = "data/sample_reviews.csv", model_path: str = "model.job
     import joblib
 
     joblib.dump(model, model_path)
-    print(f"Model saved to {model_path}")
+    logging.getLogger(__name__).info("Model saved to %s", model_path)
 
 
 if __name__ == "__main__":
@@ -25,5 +27,5 @@ if __name__ == "__main__":
     parser.add_argument("--csv", default="data/sample_reviews.csv", help="Training data CSV")
     parser.add_argument("--model", default="model.joblib", help="Where to save the model")
     args = parser.parse_args()
-
+    logging.basicConfig(format="%(message)s", level=logging.INFO, force=True)
     main(args.csv, args.model)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -7,6 +7,11 @@ def test_clean_text():
     assert preprocessing.clean_text(text) == "hello"
 
 
+def test_clean_text_collapses_spaces():
+    text = "Hello   world"
+    assert preprocessing.clean_text(text) == "hello world"
+
+
 def test_clean_text_lemmatizes_running():
     text = "running"
     clean = preprocessing.clean_text(text)

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -14,7 +14,7 @@ def test_webapp_predict_endpoint(tmp_path):
     model_file = tmp_path / 'model.joblib'
     joblib.dump(model, model_file)
 
-    webapp._model_cache.clear()
+    webapp.load_model.cache_clear()
     webapp.MODEL_PATH = str(model_file)
 
     with webapp.app.test_client() as client:
@@ -29,7 +29,7 @@ def test_webapp_root_endpoint(tmp_path):
 
     model_file = tmp_path / 'model.joblib'
     joblib.dump(build_model().fit(["good", "bad"], ["positive", "negative"]), model_file)
-    webapp._model_cache.clear()
+    webapp.load_model.cache_clear()
     webapp.MODEL_PATH = str(model_file)
 
     with webapp.app.test_client() as client:


### PR DESCRIPTION
## Summary
- collapse repeated spaces in `clean_text`
- test that `clean_text` collapses whitespace

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d2e3986088329aedf99a0049521ac

## Summary by Sourcery

Improve whitespace handling in preprocessing and streamline NLTK initialization, logging, and host binding across the CLI, webapp, and scripts

New Features:
- Collapse repeated spaces into a single space in clean_text

Enhancements:
- Introduce lazy NLTK data downloads in aspect_sentiment and preprocessing modules
- Replace print statements with consistent logger.info and basic logging setup in CLI, evaluate, predict, train, and model_comparison scripts
- Switch default server bind address from 0.0.0.0 to 127.0.0.1 for safety and clarify exposure with a flag
- Use @lru_cache to simplify model caching in the webapp
- Catch specific exceptions when building optional transformer models

Deployment:
- Update Dockerfile command to bind the container server to 0.0.0.0

Documentation:
- Clarify default host and external access options in README

Tests:
- Add test to verify clean_text collapses whitespace
- Update webapp tests to clear cache via load_model.cache_clear

Chores:
- Add .dockerignore file to exclude unnecessary files