### PR TITLE
Improve cross-validation strategy

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,10 +1,10 @@
 # Development Plan
 
 ## Phase 1: Upcoming Work
-- [ ] Add Naive Bayes model implementation in `models.py`.
-- [ ] Update `model_comparison.py` to evaluate transformer models.
-- [ ] Improve preprocessing with lemmatization and additional normalization.
-- [ ] Extend evaluation utilities with cross-validation support.
+- [x] Add Naive Bayes model implementation in `models.py`.
+- [x] Update `model_comparison.py` to evaluate transformer models.
+- [x] Improve preprocessing with lemmatization and additional normalization.
+- [x] Extend evaluation utilities with cross-validation support.
 
 ## Completed Tasks
 - [x] Initialize Git repository and configure remote

--- a/README.md
+++ b/README.md
@@ -128,6 +128,33 @@ sentiment-cli analyze data/labeled_reviews.csv
    ```bash
    python -m src.model_comparison
    ```
+16. Evaluate a model using stratified k-fold cross-validation:
+   ```python
+   from src.evaluate import cross_validate
+   import pandas as pd
+
+   data = pd.read_csv("data/sample_reviews.csv")
+   score = cross_validate(data["text"], data["label"], folds=5)
+   print(f"CV accuracy: {score:.2f}")  # texts and labels must be the same length
+   # Use a different model:
+   from src.models import build_nb_model
+   nb_score = cross_validate(
+       data["text"],
+       data["label"],
+       folds=5,
+       model_fn=build_nb_model,
+   )
+   print(f"NB CV accuracy: {nb_score:.2f}")
+   # cross_validate uses StratifiedKFold to keep label ratios consistent
+   ```
+17. Run stratified cross-validation from the CLI:
+   ```bash
+   sentiment-cli crossval data/sample_reviews.csv --folds 3
+   ```
+   Use macro F1 instead of accuracy:
+   ```bash
+   sentiment-cli crossval data/sample_reviews.csv --metric f1
+   ```
 
 Model comparison results are available in
 [docs/MODEL_RESULTS.md](docs/MODEL_RESULTS.md).

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -7,6 +7,7 @@ The `src.evaluate` module provides the following utilities:
 - `evaluate` – returns a text classification report.
 - `compute_confusion` – returns a confusion matrix as a list of lists.
 - `analyze_errors` – returns a DataFrame with misclassified examples.
+- `cross_validate` – runs stratified k-fold validation and returns the mean score.
 
 Example usage:
 
@@ -21,6 +22,43 @@ preds = model.predict(reviews["text"])
 print(evaluate(reviews["label"], preds))
 print(compute_confusion(reviews["label"], preds))
 print(analyze_errors(reviews["text"], reviews["label"], preds))
+score = cross_validate(reviews["text"], reviews["label"], folds=5)
+print(f"CV accuracy: {score:.2f}")
+# StratifiedKFold is used to keep label distribution consistent across folds
+```
+
+`cross_validate` accepts an optional `scorer` callable if you want to
+evaluate metrics other than accuracy. The `folds` parameter must be an
+integer greater than one. ``texts`` and ``labels`` must be the same length.
+For example, to compute macro F1 instead:
+
+```python
+from sklearn.metrics import f1_score
+score = cross_validate(
+    reviews["text"],
+    reviews["label"],
+    folds=5,
+    scorer=lambda y_true, y_pred: f1_score(y_true, y_pred, average="macro"),
+)
+```
+
+You can supply a custom model builder to evaluate different architectures:
+
+```python
+from src.models import build_nb_model
+score = cross_validate(
+    reviews["text"],
+    reviews["label"],
+    folds=5,
+    model_fn=build_nb_model,
+)
+```
+
+You can also run cross-validation from the command line:
+
+```bash
+sentiment-cli crossval data/sample_reviews.csv --folds 5
+sentiment-cli crossval data/sample_reviews.csv --metric f1
 ```
 
 These utilities help identify where the model is making mistakes so you can

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,59 @@ def test_cli_summary_top_respects_limit(tmp_path):
     assert "cherry" not in out
 
 
+def test_cli_crossval_runs(tmp_path):
+    pytest.importorskip("pandas")
+    pytest.importorskip("sklearn")
+
+    import pandas as pd
+
+    csv = tmp_path / "data.csv"
+    pd.DataFrame(
+        {"text": ["good", "bad", "good", "bad"], "label": ["pos", "neg", "pos", "neg"]}
+    ).to_csv(csv, index=False)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "src.cli", "crossval", str(csv), "--folds", "2"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Cross-val score:" in result.stdout
+
+
+def test_cli_crossval_custom_metric(tmp_path):
+    pytest.importorskip("pandas")
+    pytest.importorskip("sklearn")
+
+    import pandas as pd
+
+    csv = tmp_path / "data.csv"
+    pd.DataFrame(
+        {"text": ["good", "bad", "good", "bad"], "label": ["pos", "neg", "pos", "neg"]}
+    ).to_csv(csv, index=False)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.cli",
+            "crossval",
+            str(csv),
+            "--folds",
+            "2",
+            "--metric",
+            "f1",
+            "--nb",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Cross-val score:" in result.stdout
+
+
 def test_cli_version(monkeypatch, capsys):
     monkeypatch.setitem(sys.modules, 'importlib.metadata', None)
     import src.cli as cli

--- a/tests/test_cross_validation.py
+++ b/tests/test_cross_validation.py
@@ -21,9 +21,62 @@ def test_cross_validate_custom_folds():
     assert 0.0 <= acc <= 1.0
 
 
+def test_cross_validate_custom_scorer():
+    pytest.importorskip("sklearn")
+    from sklearn.metrics import f1_score
+
+    texts = ["good", "bad", "good", "bad"]
+    labels = ["positive", "negative", "positive", "negative"]
+
+    score = cross_validate(
+        texts,
+        labels,
+        folds=2,
+        scorer=lambda y_true, y_pred: f1_score(y_true, y_pred, pos_label="positive"),
+    )
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+
+
+def test_cross_validate_custom_model_fn():
+    pytest.importorskip("sklearn")
+    from src.models import build_nb_model
+
+    texts = ["good", "bad", "good", "bad"]
+    labels = ["positive", "negative", "positive", "negative"]
+
+    score = cross_validate(texts, labels, folds=2, model_fn=build_nb_model)
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+
+
 def test_cross_validate_insufficient_data():
     pytest.importorskip("sklearn")
     texts = ["good", "bad"]
     labels = ["positive", "negative"]
     with pytest.raises(ValueError):
         cross_validate(texts, labels, folds=3)
+
+
+def test_cross_validate_invalid_folds():
+    pytest.importorskip("sklearn")
+    texts = ["good", "bad", "good"]
+    labels = ["pos", "neg", "pos"]
+    with pytest.raises(ValueError):
+        cross_validate(texts, labels, folds=1)
+
+
+def test_cross_validate_non_int_folds():
+    pytest.importorskip("sklearn")
+    texts = ["good", "bad", "good"]
+    labels = ["pos", "neg", "pos"]
+    with pytest.raises(TypeError):
+        cross_validate(texts, labels, folds=2.5)
+
+
+def test_cross_validate_length_mismatch():
+    pytest.importorskip("sklearn")
+    texts = ["good", "bad", "good"]
+    labels = ["pos", "neg"]
+    with pytest.raises(ValueError):
+        cross_validate(texts, labels, folds=2)


### PR DESCRIPTION
## Summary
- use `StratifiedKFold` in `cross_validate` to keep label ratios stable
- clarify stratified CV usage in the README and evaluation guide

## Testing
- `ruff check .`
- `bandit -r src -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686000246a9083299105f25c94485f47

## Summary by Sourcery

Implement stratified k-fold cross-validation in the evaluation module with customizable scoring and model building, expose it via a new CLI `crossval` subcommand, and update documentation and tests to reflect the changes.

New Features:
- Add CLI `crossval` command to perform stratified k-fold cross-validation
- Expose optional `scorer` and `model_fn` parameters in `cross_validate` for custom metrics and models

Enhancements:
- Replace `KFold` with `StratifiedKFold` and add input validations (folds type, minimum folds, dataset length) in `cross_validate`

Documentation:
- Update README and EVALUATION guide with examples and explanations for stratified cross-validation

Tests:
- Add unit tests for `cross_validate` error conditions, custom scorer/model functions, and CLI cross-validation command